### PR TITLE
Remove linking of elementresponse to casacore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,9 @@ add_library(elementresponse SHARED
 set_target_properties(stationresponse PROPERTIES VERSION 2)
 set_target_properties(elementresponse PROPERTIES VERSION 2)
 
+# The elementresponse lib does not require casacore, so
+# linking casacore only to stationresponse is enough.
 target_link_libraries(stationresponse ${CASACORE_LIBRARIES})
-target_link_libraries(elementresponse ${CASACORE_LIBRARIES})
 
 install (TARGETS stationresponse DESTINATION lib)
 install (TARGETS elementresponse DESTINATION lib)


### PR DESCRIPTION
As noted in #8, it is not necessary to link elementresponse to casacore, because casacore is not used in elementresponse. This avoids the casacore dependency in the debian elemtnresponse packages.