### PR TITLE
increment SO version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,8 @@ add_library(stationresponse SHARED
 add_library(elementresponse SHARED
   ElementResponse.cc)
 
-set_target_properties(stationresponse PROPERTIES VERSION 2)
-set_target_properties(elementresponse PROPERTIES VERSION 2)
+set_target_properties(stationresponse PROPERTIES VERSION 3)
+set_target_properties(elementresponse PROPERTIES VERSION 3)
 
 # The elementresponse lib does not require casacore, so
 # linking casacore only to stationresponse is enough.


### PR DESCRIPTION
as reported here:

https://github.com/kernsuite/packaging/issues/188

the stationresponse and elementresponse libs are not ABI compatible with the old LOFAR software versions, so we should increment the SO version