### PR TITLE
Add python 3 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 3.0.0)
 
 project(lofarbeam)
 
@@ -8,7 +8,7 @@ set(CASACORE_MAKE_REQUIRED_EXTERNALS_OPTIONAL TRUE)
 find_package(Casacore REQUIRED COMPONENTS casa ms tables measures)
 include_directories(${CASACORE_INCLUDE_DIR})
 
-add_compile_options(-std=c++11 -Wall -DNDEBUG)
+add_compile_options(-std=c++11 -Wall -DNDEBUG -Wl,--no-undefined)
 
 add_library(stationresponse SHARED
   AntennaField.cc
@@ -66,16 +66,36 @@ elseif(DOXYGEN_FOUND)
 endif(DOXYGEN_FOUND)
 
 find_package (Python COMPONENTS Development)
-find_package(Boost COMPONENTS python)
-find_package(Casacore REQUIRED COMPONENTS python)
+message("Compiling Python ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR} support. If this is not the intended target use 'DPYTHON_EXECUTABLE' to control.")
+# bind against boost-python for compilation of the python API
+# depending on major release version of the python libraries
+if (${PYTHON_VERSION_MAJOR} VERSION_LESS "3")
+  find_package (Boost REQUIRED COMPONENTS python numpy)
+  find_package (Casacore REQUIRED COMPONENTS python)
+  message(STATUS "Boost python library: ${Boost_PYTHON_LIBRARY}")
+  message(STATUS "Boost numpy library: ${Boost_NUMPY_LIBRARY}")
+  message(STATUS "Python library ${PYTHON_LIBRARIES}")
+  set(BOOST_PY_FOUND TRUE)
+else (${PYTHON_VERSION_MAJOR} VERSION_LESS "3")
+  find_package (Boost REQUIRED COMPONENTS python3 numpy3)
+  find_package (Casacore REQUIRED COMPONENTS python3)
+  message(STATUS "Boost python library: ${Boost_PYTHON3_LIBRARY}")
+  message(STATUS "Boost numpy library: ${Boost_NUMPY3_LIBRARY}")
+  message(STATUS "Python library ${PYTHON_LIBRARIES}")
+  set(BOOST_PY_FOUND TRUE)
+endif (${PYTHON_VERSION_MAJOR} VERSION_LESS "3")
 
-if(Boost_PYTHON_FOUND)
+
+if(BOOST_PY_FOUND)
     add_library(_stationresponse MODULE pystationresponse.cc)
     set_target_properties(_stationresponse PROPERTIES PREFIX "")
     target_include_directories(_stationresponse PRIVATE ${PYTHON_INCLUDE_DIR} ${Boost_INCLUDE_DIRS})
-    target_link_libraries(_stationresponse stationresponse ${CASA_PYTHON_LIBRARY} ${Boost_PYTHON_LIBRARY})
+    if (${PYTHON_VERSION_MAJOR} VERSION_LESS "3")
+      target_link_libraries(_stationresponse stationresponse ${CASA_PYTHON_LIBRARY} ${Boost_PYTHON_LIBRARY} ${Boost_NUMPY_LIBRARY} ${PYTHON_LIBRARIES})
+    else (${PYTHON_VERSION_MAJOR} VERSION_LESS "3")
+      target_link_libraries(_stationresponse stationresponse ${CASA_PYTHON3_LIBRARY} ${Boost_PYTHON3_LIBRARY} ${Boost_NUMPY3_LIBRARY} ${PYTHON_LIBRARIES})
+    endif (${PYTHON_VERSION_MAJOR} VERSION_LESS "3")
     install(TARGETS _stationresponse DESTINATION ${PYTHON_INSTALL_DIR}/lofar/stationresponse)
     install(FILES __init__.py DESTINATION ${PYTHON_INSTALL_DIR}/lofar/stationresponse)
-
-endif(Boost_PYTHON_FOUND)
+endif(BOOST_PY_FOUND)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:18.04
+
+RUN apt-get update
+RUN apt-get install -y libboost-all-dev \
+		               build-essential \
+                       libpython3-dev \
+                       python3-dev \
+                       python3-numpy \
+		               gfortran \
+		               wget \
+                       libsofa1-dev \
+                       flex \
+                       bison \
+                       libbison-dev \
+                       libatlas-base-dev \
+                       liblapack-dev \
+                       libcfitsio-dev \
+                       wcslib-dev \
+                       cmake 
+
+#####################################################################
+## BUILD CASACORE FROM SOURCE
+#####################################################################
+RUN mkdir /src
+WORKDIR /src
+RUN wget https://github.com/casacore/casacore/archive/v3.1.1.tar.gz
+RUN tar xvf v3.1.1.tar.gz
+RUN mkdir casacore-3.1.1/build
+WORKDIR /src/casacore-3.1.1/build
+RUN cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DBUILD_DEPRECATED=ON -DBUILD_PYTHON=OFF -DBUILD_PYTHON3=ON ../
+RUN make -j 4
+RUN make install
+RUN ldconfig
+
+RUN apt-get install -y python3-pip
+WORKDIR /src
+RUN rm v3.1.1.tar.gz
+RUN wget https://github.com/casacore/python-casacore/archive/v3.1.1.tar.gz
+RUN tar xvf v3.1.1.tar.gz
+WORKDIR /src/python-casacore-3.1.1
+RUN pip3 install .
+WORKDIR /
+RUN python3 -c "from pyrap.tables import table as tbl"
+
+#####################################################################
+## BUILD STATION RESPONSE FROM SOURCE
+#####################################################################
+ADD . /src
+WORKDIR /src
+RUN mkdir build
+RUN cd build && cmake -DCMAKE_INSTALL_PREFIX=/usr -DPYTHON_EXECUTABLE=$(which python3) ../ && make -j16 && make install
+RUN touch "/usr/lib/python3.6/site-packages/lofar/__init__.py"
+# installs in the site-packages for some reason, need to add this to the search path
+ENV PYTHONPATH "/usr/lib/python3.6/site-packages:$PYTHONPATH"
+RUN python3 -c "import lofar.stationresponse as lsr"
+

--- a/__init__.py
+++ b/__init__.py
@@ -18,8 +18,9 @@
 # with the LOFAR software suite. If not, see <http://www.gnu.org/licenses/>.
 #
 # $Id: __init__.py 33126 2015-12-11 19:09:42Z dijkema $
+from __future__ import absolute_path, print_function, division
 
-import _stationresponse
+from . import _stationresponse
 
 class stationresponse(object):
     """

--- a/__init__.py
+++ b/__init__.py
@@ -18,7 +18,7 @@
 # with the LOFAR software suite. If not, see <http://www.gnu.org/licenses/>.
 #
 # $Id: __init__.py 33126 2015-12-11 19:09:42Z dijkema $
-from __future__ import absolute_path, print_function, division
+from __future__ import absolute_import, print_function, division
 
 from . import _stationresponse
 


### PR DESCRIPTION
This adds python 3 binding support for the LOFAR beams package.
I've also added a dockerfile as a first pass for something that could become a jenkins/travis test.