### PR TITLE
Fix PythonInstall.cmake

### DIFF
--- a/CMake/PythonInstall.cmake
+++ b/CMake/PythonInstall.cmake
@@ -42,9 +42,11 @@ if(PYTHON_EXECUTABLE)
     RESULT_VARIABLE _pyres
     OUTPUT_STRIP_TRAILING_WHITESPACE)
   if(NOT _pyres EQUAL 0)
-    message(FATAL_ERROR "${_pyerr}")
+    message(FATAL_ERROR "Python command failed:\n${_pyerr}")
   else()
-    message(WARNING "${_pyerr}")
+    if(_pyerr)
+      message(WARNING "${_pyerr}")
+    endif()
   endif()
   
   if(NOT DEFINED PYTHON_BUILD_DIR)

--- a/CMake/PythonInstall.cmake
+++ b/CMake/PythonInstall.cmake
@@ -39,10 +39,13 @@ if(PYTHON_EXECUTABLE)
     COMMAND "${PYTHON_EXECUTABLE}" "-c" "${_cmd}"
     OUTPUT_VARIABLE _pydir
     ERROR_VARIABLE _pyerr
+    RESULT_VARIABLE _pyres
     OUTPUT_STRIP_TRAILING_WHITESPACE)
-  if(_pyerr)
-    message(FATAL_ERROR "Python command failed:\n${_pyerr}")
-  endif(_pyerr)
+  if(NOT _pyres EQUAL 0)
+    message(FATAL_ERROR "${_pyerr}")
+  else()
+    message(WARNING "${_pyerr}")
+  endif()
   
   if(NOT DEFINED PYTHON_BUILD_DIR)
     set(_PRINT_PYTHON_DIRS TRUE)


### PR DESCRIPTION
Currently, if the python command to determine the install directory emits a warning message to `stderr`, this is treated as an error. Instead of checking the contents of `stderr`, the return value of the python command is now checked.